### PR TITLE
collect and propogate loader errors

### DIFF
--- a/samples/loaders/postloader.fsx
+++ b/samples/loaders/postloader.fsx
@@ -93,12 +93,15 @@ let loadFile n =
       tags = tags
       content = content }
 
-let loader (projectRoot: string) (siteContet: SiteContents) =
+let loader (projectRoot: string) (siteContent: SiteContents) =
     let postsPath = System.IO.Path.Combine(projectRoot, "posts")
     System.IO.Directory.GetFiles postsPath
     |> Array.filter (fun n -> n.EndsWith ".md")
-    |> Array.map loadFile
-    |> Array.iter (fun p -> siteContet.Add p)
-
-    siteContet.Add({disableLiveRefresh = false})
-    siteContet
+    |> Array.iter 
+        (fun path ->
+            try 
+                siteContent.Add (loadFile path)
+            with _ -> 
+                siteContent.AddError {Path = path; Message = (sprintf "Uable to load post %s" path); Phase = Loading})
+    siteContent.Add({disableLiveRefresh = false})
+    siteContent

--- a/src/Fornax.Core/Model.fs
+++ b/src/Fornax.Core/Model.fs
@@ -1271,8 +1271,31 @@ type CSSProperties =
 
 open System.Collections.Generic
 
+type SiteErrors = string list
+
+type GenerationPhase = 
+| Loading
+| Generating
+type SiteError = {
+    Path : string
+    Message : string
+    Phase : GenerationPhase
+}
+
 type SiteContents () =
     let container = new System.ComponentModel.Design.ServiceContainer()
+    let errors = new Dictionary<string, SiteError>()
+
+    member __.AddError error =
+        errors.Add(error.Path, error)
+
+    member __.TryGetError path =
+        match errors.TryGetValue path with
+        | true, v -> Some v
+        | _ -> None
+
+    member __.Errors () =
+        List.ofSeq errors.Values    
 
     member __.Add(value:'a) =
         let key = typeof<List<'a>>

--- a/src/Fornax/Generator.fs
+++ b/src/Fornax/Generator.fs
@@ -63,7 +63,7 @@ module EvaluatorHelpers =
             | true ->
                 Some next
         helper f (args |> List.ofSeq )
-        
+
     let internal compileExpression (input : FsiValue) =
         let genExpr = input.ReflectionValue :?> Quotations.Expr
         QuotationEvaluator.CompileUntyped genExpr
@@ -369,12 +369,11 @@ let generateFolder (projectRoot : string) =
             ||> Array.fold (fun state e ->
                 match LoaderEvaluator.evaluate fsi state e projectRoot with
                 | Ok sc ->
-                    printfn "Errors %O" sc.Errors
-                    sc.Errors() |> List.iter (fun er -> printfn "FAILED POST: %s" er.Path)
                     sc
                 | Error er ->
                     printfn "LOADER ERROR: %s" er
                     state)
+        sc.Errors() |> List.iter (fun er -> printfn "BAD FILE: %s" er.Path)
 
 
         let logResult (result : GeneratorResult) =

--- a/src/Fornax/Generator.fs
+++ b/src/Fornax/Generator.fs
@@ -63,7 +63,7 @@ module EvaluatorHelpers =
             | true ->
                 Some next
         helper f (args |> List.ofSeq )
-
+        
     let internal compileExpression (input : FsiValue) =
         let genExpr = input.ReflectionValue :?> Quotations.Expr
         QuotationEvaluator.CompileUntyped genExpr
@@ -114,13 +114,12 @@ module LoaderEvaluator =
         runLoader fsi loaderPath
         |> Result.bind (fun ft ->
             let generator = compileExpression ft
-            let res = invokeFunction generator [box projectRoot; box siteContent]
-
-            res
-            |> Option.bind (tryUnbox<SiteContents>)
+            invokeFunction generator [box projectRoot; box siteContent] 
             |> function
-                | Some s -> Ok s
-                | None -> sprintf "The expression for %s couldn't be compiled" loaderPath |> Error)
+                | Some r -> 
+                    try r :?> SiteContents |> Ok
+                    with _ -> sprintf "File loader %s incorrect return type" loaderPath |> Error
+                | None -> sprintf "File loader %s couldn't be compiled" loaderPath |> Error)
 
 module GeneratorEvaluator =
     open FSharp.Compiler.Interactive.Shell
@@ -171,11 +170,11 @@ module GeneratorEvaluator =
         |> Result.bind (fun ft ->
             let generator = compileExpression ft
 
-            invokeFunction generator [box siteContent; box projectRoot; box page ]
+            invokeFunction generator [box siteContent; box projectRoot; box page ] 
             |> Option.bind (tryUnbox<string>)
             |> function
                 | Some s -> Ok s
-                | None -> sprintf "The expression for %s couldn't be compiled" generatorPath |> Error)
+                | None -> sprintf "HTML generator %s couldn't be compiled" generatorPath |> Error)
 
 module ConfigEvaluator =
     open FSharp.Compiler.Interactive.Shell
@@ -230,7 +229,7 @@ module ConfigEvaluator =
                 | Some s ->
                     siteContent.Add s
                     Ok s
-                | None -> sprintf "The expression for %s couldn't be compiled" generatorPath |> Error)
+                | None -> sprintf "Configuration evaluator %s couldn't be compiled" generatorPath |> Error)
 
 exception FornaxGeneratorException of string
 
@@ -242,13 +241,17 @@ type GeneratorResult =
     | GeneratorFailure of GeneratorMessage
 
 let pickGenerator (cfg: Config.Config)  (siteContent : SiteContents) (projectRoot : string) (page: string) =
-    let generator = cfg.Generators |> List.tryFind (fun n ->
-        match n.Trigger with
-        | Once -> false //Once-trigger run globally, not for particular file
-        | OnFile fn -> fn = page
-        | OnFileExt ex -> ex = Path.GetExtension page
-        | OnFilePredicate pred -> pred (projectRoot, page)
-    )
+    let generator = 
+        match siteContent.TryGetError page with
+        | Some _ -> None
+        | None -> 
+            cfg.Generators |> List.tryFind (fun n ->
+                match n.Trigger with
+                | Once -> false //Once-trigger run globally, not for particular file
+                | OnFile fn -> fn = page
+                | OnFileExt ex -> ex = Path.GetExtension page
+                | OnFilePredicate pred -> pred (projectRoot, page)
+            )
     match generator with
     | None -> None
     | Some generator ->
@@ -358,7 +361,7 @@ let generateFolder (projectRoot : string) =
 
     match config with
     | None ->
-        raise (FornaxGeneratorException "Cpuldn't find or load config")
+        raise (FornaxGeneratorException "Couldn't find or load config")
     | Some config ->
         let loaders = Directory.GetFiles(Path.Combine(projectRoot, "loaders"), "*.fsx")
         let sc =
@@ -366,6 +369,8 @@ let generateFolder (projectRoot : string) =
             ||> Array.fold (fun state e ->
                 match LoaderEvaluator.evaluate fsi state e projectRoot with
                 | Ok sc ->
+                    printfn "Errors %O" sc.Errors
+                    sc.Errors() |> List.iter (fun er -> printfn "FAILED POST: %s" er.Path)
                     sc
                 | Error er ->
                     printfn "LOADER ERROR: %s" er


### PR DESCRIPTION
Currently if a generator operates over invalid page data it is not able to express this in a nice way. For example if a post.md file is missing title in the top matter this is the result:

```
An unexpected error happend: Exception has been thrown by the target of an invocation.
... more useless logging which tells you nothing
```

To see this happen simply add a new file to the /posts director while in watch mode. The result is an immediate exception and termination of watch mode. 

My first thought was to catch the invocation exception and indicate which page is failing during the load/generation phase.

That results in this:

```
The expression for /Users/joergbeekmann/Documents/Fornax/FornaxDemo/generators/post.fsx either couldn't be compiled or experianced a runtime
[11:34:23] '/Users/joergbeekmann/Documents/Fornax/FornaxDemo/_public/posts/post2.html' generation failed
```
Better, at least you know which page it is. But there is no way for the generator to indicate what is wrong with the markdown on the page. In this case a missing title.

This PR explores how to collect errors that occur during the load phase and then surface them as notifications in the console. That results in the following:
```
[10:03:28] Watch mode started. Press any key to exit.
[10:03:28 INF] Smooth! Suave listener started in 35.71ms with binding 127.0.0.1:8080
[10:03:44] Changes detected: /Users/joergbeekmann/Documents/FornexDemo/posts/post3.md
BAD FILE: /Users/joergbeekmann/Documents/FornexDemo/posts/post3.md
[10:03:44] '/Users/joergbeekmann/Documents/FornexDemo/_public/index.html' generated in 161ms
[10:03:44] '/Users/joergbeekmann/Documents/FornexDemo/_public/about.html' generated in 126ms
```

This PR is a proof of concept to go with issue #44.
